### PR TITLE
Update dependencies: psycopg2-binary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ params = dict(
 			'pytest-flake8',
 
 			# local
-			'psycopg2',
+			'psycopg2-binary',
 		],
 		'docs': [
 			# upstream


### PR DESCRIPTION
I stumbled upon that today when trying to run tests with `tox` in one of our docker container. We've recently removed all dependencies that we only need for testing, which included the Postgres related libs. Now that `jaraco.postgres` depends on `psycopg2` you need to have `postgres-dev` (or contrib?) installed.

This change makes it possible to have lightweight docker containers utilizing a postgres service in Gitlab while still supporting `jaraco.postgres` for local development

(see also https://github.com/psycopg/psycopg2/issues/699 I ran into this using `Python:2.7-alpine`)